### PR TITLE
lock yarn version at 1.2.1 to avoid http_proxy env issue

### DIFF
--- a/Dockerfile.nodejs-6
+++ b/Dockerfile.nodejs-6
@@ -17,7 +17,7 @@ RUN echo "deb http://deb.nodesource.com/node_6.x xenial main" > /etc/apt/sources
 # Install
 RUN apt-get -qq install -y \
     nodejs \
-    yarn
+    yarn=1.2.1-1
 
 # Cleanup
 RUN apt-get -qq clean && \

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It uses same directory layout for defining services, patched versions of `my_ini
 
 ### Container control
 
-* <a href="#container-lifecyle">Lifecycle</a>
+* <a href="#container-lifecycle">Lifecycle</a>
 * <a href="#enabling-services">Enabling integrated services</a>
 * <a href="#sudo-su">Running as another user</a>
 


### PR DESCRIPTION
issue url: https://github.com/yarnpkg/yarn/issues/4885
also fix typo at README.md